### PR TITLE
spec includes too many files in bosh_softlayer_cpi

### DIFF
--- a/packages/bosh_softlayer_cpi/spec
+++ b/packages/bosh_softlayer_cpi/spec
@@ -1,11 +1,8 @@
 ---
 name: bosh_softlayer_cpi
 
-dependencies: [golang_1.5.3]
+dependencies:
+- golang_1.5.3
 
 files:
-- "**/*"
-
-excluded_files:
-- github.com/onsi/ginkgo/**/*
-- github.com/onsi/gomega/**/*
+- bosh-softlayer-cpi/**/*


### PR DESCRIPTION
By including `**/*`, the package included all of the binary blobs and source code from all of the packages in the release.

This change reduces the size of the release tarball from 155M to 79M.
