### PR TITLE
CPI script bails on error

### DIFF
--- a/jobs/softlayer_cpi/templates/cpi.erb
+++ b/jobs/softlayer_cpi/templates/cpi.erb
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 pkgs_dir=${BOSH_PACKAGES_DIR:-/var/vcap/packages}
 jobs_dir=${BOSH_JOBS_DIR:-/var/vcap/jobs}
 

--- a/jobs/softlayer_cpi/templates/cpi_ctl.erb
+++ b/jobs/softlayer_cpi/templates/cpi_ctl.erb
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 LOG_DIR=/var/vcap/sys/log/softlayer_cpi
 RUN_DIR=/var/vcap/sys/run/softlayer_cpi
 PIDFILE=$RUN_DIR/cpi.pid


### PR DESCRIPTION
- The CPI script as it stands shouldn't ever error-out; this
  PR is merely about laying the groundwork for the future
  if the script becomes more complicated (e.g. passing
  in environment variables such as HTTPS_PROXY) -- we'd
  want the script to abort as soon as it encountered an
  error (we chased down a bug in the vSphere CPI which was
  caused partly by the CPI script not aborting).

[#128097379](https://www.pivotaltracker.com/story/show/128097379)

Signed-off-by: Brian Cunnie bcunnie@pivotal.io
