### PR TITLE
Make it possible use this release on macOS

### DIFF
--- a/packages/bosh_softlayer_cpi/packaging
+++ b/packages/bosh_softlayer_cpi/packaging
@@ -15,7 +15,7 @@ mkdir src && cp -a github.com src
 
 ls -l src
 cd src/github.com/cloudfoundry/bosh-softlayer-cpi
-bin/build-linux-amd64
+bin/build-amd64
 
 mkdir -p $BOSH_INSTALL_TARGET/bin
 cp out/softlayer_cpi $BOSH_INSTALL_TARGET/bin/softlayer_cpi

--- a/packages/golang_1.7.1/packaging
+++ b/packages/golang_1.7.1/packaging
@@ -1,6 +1,12 @@
-# abort script on any command that exits with a non zero value
-set -e
+set -e # exit immediately if a simple command exits with a non-zero status
+set -u # report the usage of uninitialized variables
 
-tar xzf golang_1.7.1/go1.7.1.linux-amd64.tar.gz
+# Grab the latest versions that are in the directory
+PLATFORM=`uname | tr '[:upper:]' '[:lower:]'`
 
-cp -R go/* ${BOSH_INSTALL_TARGET}
+# Extract Go Programming Language package
+tar xzvf ${BOSH_COMPILE_TARGET}/golang_1.7.1/go1.7.1.${PLATFORM}-amd64.tar.gz
+
+# Copy Go Programming Language package
+mkdir -p ${BOSH_INSTALL_TARGET}/bin
+cp -a ${BOSH_COMPILE_TARGET}/go/* ${BOSH_INSTALL_TARGET}

--- a/packages/golang_1.7.1/spec
+++ b/packages/golang_1.7.1/spec
@@ -5,3 +5,4 @@ dependencies:
 
 files:
   - golang_1.7.1/go1.7.1.linux-amd64.tar.gz # https://storage.googleapis.com/golang/go1.7.1.linux-amd64.tar.gz
+  - golang_1.7.1/go1.7.1.darwin-amd64.tar.gz # https://storage.googleapis.com/golang/go1.7.1.darwin-amd64.tar.gz


### PR DESCRIPTION
Addresses https://github.com/cloudfoundry/bosh-softlayer-cpi/issues/148.

Note:
1. https://github.com/cloudfoundry/bosh-softlayer-cpi/pull/189 needs to be merged first.
2. https://storage.googleapis.com/golang/go1.7.1.darwin-amd64.tar.gz needs to be available in the blobstore (see `packages/golang_1.7.1/spec` below).